### PR TITLE
Refactor: Experience Item for every job

### DIFF
--- a/src/components/ExperienceItem/ExperienceItem.jsx
+++ b/src/components/ExperienceItem/ExperienceItem.jsx
@@ -1,0 +1,16 @@
+// import { useState } from 'react';
+import './ExperienceItem.css';
+
+export const ExperienceItem = ({jobItem}) => {
+
+    const {company, title, location, startDate, endDate, description} = jobItem;
+
+  return (
+    <div>
+            <h3>{company}</h3>
+            <h4>{title}</h4>
+            <p>{location} | {startDate} - {endDate}</p>
+            <p>{description}</p>
+        </div>
+  );
+};

--- a/src/components/ExperienceList/ExperienceList.jsx
+++ b/src/components/ExperienceList/ExperienceList.jsx
@@ -1,17 +1,13 @@
 // import { useState } from 'react';
+import { ExperienceItem } from '../ExperienceItem/ExperienceItem';
 import './ExperienceList.css';
 
 export const ExperienceList = ({experience}) => {
 
   return (
     <div className='experience-list'>
-    {experience.map((item) => (
-        <div key={`${item.company}-${item.title}`}>
-            <h3>{item.company}</h3>
-            <h4>{item.title}</h4>
-            <p>{item.location} | {item.startDate} - {item.endDate}</p>
-            <p>{item.description}</p>
-        </div>
+    {experience.map((jobItem) => (
+        <ExperienceItem key={jobItem.id} jobItem={jobItem}/>
         )
     )}
      

--- a/src/data/cvData.js
+++ b/src/data/cvData.js
@@ -12,6 +12,7 @@ const cvData = {
 
 	experience: [
 		{
+			id: 1,
 			title: "Frontend Engineer",
 			company: "Rocket418",
 			location: "Madrid, España",
@@ -21,6 +22,7 @@ const cvData = {
 				"Desarrollo de nuevas funcionalidades en React y refactorización de código heredado. Mejora del sistema de navegación y experiencia de usuario.",
 		},
 		{
+			id: 2,
 			title: "Redactor SEO",
 			company: "Atresmedia",
 			location: "Madrid, España",
@@ -30,6 +32,7 @@ const cvData = {
 				"Implementación y creación de estrategias globales para contenido SEO de laSexta.com",
 		},
 		{
+			id: 3,
 			title: "Técnico de marketing",
 			company: "Atresmedia",
 			location: "Madrid, España",
@@ -39,6 +42,7 @@ const cvData = {
 				"Redacción y gestión de promociones de contenidos para Atresmedia, elaborando informes diarios, coordinando la comunicación interna y analizando el impacto de las campañas.",
 		},
 		{
+			id: 4,
 			title: "Jefe de redacción",
 			company: "Toigo Radio",
 			location: "Salamanca, España",
@@ -48,6 +52,7 @@ const cvData = {
 				"Gestión de equipo para redacción de contenidos en la web. Realizador de Informa2, los informativos de tarde emitidos en el mes de mayo. Gestión de redes sociales.",
 		},
 		{
+			id: 5,
 			title: "Intérprete y operario de máquinas",
 			company: "Hergon Metropolitan UK Limited",
 			location: "Londres, UK",
@@ -60,6 +65,7 @@ const cvData = {
 
 	education: [
 		{
+			id: 1,
 			degree: "Bootcamp de desarrollo front-end (Remoto)",
 			institution: "Upgrade hub",
 			location: "Madrid, España",
@@ -69,6 +75,7 @@ const cvData = {
 				"Desarrollo web con enfoque en HTML, CSS, JavaScript, TypeScript, Angular y React.",
 		},
 		{
+			id: 2,
 			degree: "Máster en Formación y Comunicación Digital",
 			institution: "EAE Business School",
 			location: "Madrid, España",
@@ -77,6 +84,7 @@ const cvData = {
 			description: "Conocimiento en marketing, branding y analítica digital.",
 		},
 		{
+			id: 3,
 			degree: "Postgrado Experto en Locución Audiovisual",
 			institution: "Universidad Pontificia de Salamanca",
 			location: "Salamanca, España",
@@ -88,37 +96,39 @@ const cvData = {
 	],
 
 	softSkills: [
-		"Arquitectura hexagonal",
-		"Resolución de problemas",
-		"Comunicación efectiva",
-		"Trabajo en equipo",
-		"Aprendizaje continuo",
+		{ id: 1, name: "Arquitectura hexagonal" },
+		{ id: 2, name: "Resolución de problemas" },
+		{ id: 3, name: "Comunicación efectiva" },
+		{ id: 4, name: "Trabajo en equipo" },
+		{ id: 5, name: "Aprendizaje continuo" },
 	],
 
 	devLanguages: [
-		{ name: "HTML", level: "professional" },
-		{ name: "CSS", level: "professional" },
-		{ name: "JavaScript", level: "professional" },
-		{ name: "TypeScript", level: "academic" },
+		{ id: 1, name: "HTML", level: "professional" },
+		{ id: 2, name: "CSS", level: "professional" },
+		{ id: 3, name: "JavaScript", level: "professional" },
+		{ id: 4, name: "TypeScript", level: "academic" },
 	],
 
 	technologies: [
-		"React",
-		"Angular",
-		"Node.js",
-		"Vite",
-		"Bootstrap",
-		"Figma",
-		"Git",
-		"SCRUM",
+		{ id: 1, name: "React" },
+		{ id: 2, name: "Angular" },
+		{ id: 3, name: "Node.js" },
+		{ id: 4, name: "Vite" },
+		{ id: 5, name: "Bootstrap" },
+		{ id: 6, name: "Figma" },
+		{ id: 7, name: "Git" },
+		{ id: 8, name: "SCRUM" },
 	],
 
 	languages: [
 		{
+			id: 1,
 			name: "Español",
 			level: "Competencia nativa o bilingüe",
 		},
 		{
+			id: 2,
 			name: "Inglés",
 			level: "Competencia profesional completa",
 		},


### PR DESCRIPTION
# Add Experience Item for every job

## Description

This pull request introduces the `ExperienceItem` component, responsible for displaying the information of a single job within the experience section of the CV. It is now properly connected to the `ExperienceList`, rendering each job entry individually with its own data.

### Changes:

- Created `ExperienceItem.jsx` inside `src/components/ExperienceItem/`
- Structured the layout for displaying job title, company, location, dates, and description
- Passed individual job data as props from `ExperienceList` to `ExperienceItem`
- Ensured each job is rendered with a unique key and accurate content

This implementation sets a clean and scalable foundation for rendering multiple professional experiences consistently.

### Screenshots
<img width="651" height="384" alt="image" src="https://github.com/user-attachments/assets/92fd7926-ca53-4fd3-b494-f66e5a4a2849" />
