### PR TITLE
PDF download button and Full CV in Interactive

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -94,3 +94,74 @@
 		row-gap: 20px;
 	}
 }
+
+/* ESTILOS PARA IMPRESIÓN PDF*/
+
+@media print {
+	body {
+		margin: 0;
+		padding: 0;
+		background: white;
+		color: black;
+	}
+
+
+	.curriculum-container,
+	.interactive-cv {
+		height: auto !important;
+		overflow: visible !important;
+		width: 100% !important;
+		max-width: 100% !important;
+		margin: 0 auto !important;
+		box-shadow: none;
+	}
+
+	html,
+	body {
+		width: 100%;
+		height: auto;
+		overflow: visible;
+		font-size: 12pt;
+	}
+
+	h1 {
+		font-size: 2em;
+	}
+
+	h2 {
+		font-size: 1.4em;
+	}
+
+	h3 {
+		font-size: 1.2em;
+	}
+
+	h4 {
+		font-size: 1.1em;
+	}
+
+	p,
+	li,
+	span,
+	a {
+		font-size: 1em;
+	}
+}
+
+@media print {
+	nav,
+	.tab-nav,
+	#dark-mode-btn,
+	.footer,
+	.download-btn {
+		display: none !important;
+	}
+}
+
+@media print {
+	section,
+	.section {
+		page-break-inside: avoid;
+		page-break-after: auto;
+	}
+}

--- a/src/components/ContactInfo/ContactInfo.css
+++ b/src/components/ContactInfo/ContactInfo.css
@@ -37,3 +37,17 @@
         width: 60px;
 	}
 }
+
+
+@media print {
+	.contact-info {
+		width: 100%;
+		align-items: center;
+		justify-content: center;
+		flex-direction: column;
+	}
+
+	.rrss {
+		display: none;
+	}
+}

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -31,7 +31,7 @@ export const Footer = ({ cvData }) => {
 				</div>
 				<div className="footer-info">
 					<p>
-						<span>📍{location}</span> | <span>📧 {email}</span>
+						📍<span>{location}</span> | 📧<span> {email}</span>
 					</p>
 				</div>
 			</div>

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -11,6 +11,9 @@ export const Footer = ({ cvData }) => {
 
 	return (
 		<div className="footer">
+			<button onClick={() => window.print()} className="download-btn">
+				📄 Descargar en PDF
+			</button>
 			<div className="footer-contact">
 				<div className="footer-rrss">
 					<div className="rrss-icon">

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -80,3 +80,14 @@
 		gap: 60px;
 	}
 }
+
+
+@media print {
+	.header {
+		flex-direction: column;
+	}
+
+	.header-info {
+		gap: 40px;
+	}
+}

--- a/src/components/InteractiveCV/InteractiveCV.jsx
+++ b/src/components/InteractiveCV/InteractiveCV.jsx
@@ -19,10 +19,11 @@ export const InteractiveCV = ({ cvData }) => {
 		languages,
 	} = cvData;
 
-	const [activeTab, setActiveTab] = useState("experience");
+	const [activeTab, setActiveTab] = useState("all");
 	const [animating, setAnimating] = useState(false);
-	const [visibleTab, setVisibleTab] = useState("experience");
+	const [visibleTab, setVisibleTab] = useState("all");
 	const tabs = [
+		{ id: "all", label: "📄 CV completo" },
 		{ id: "experience", label: "📋 Experiencia" },
 		{ id: "education", label: "🎓 Educación" },
 		{ id: "it-skills", label: "🖥️ Competencias informáticas" },
@@ -59,18 +60,15 @@ export const InteractiveCV = ({ cvData }) => {
 				))}
 			</div>
 			<div className="interactive-content">
-				{currentTab && (
-					<Section
-						title={currentTab.label}
-						className={animating ? "scroll-collapse" : "scroll-expand"}
-					>
-						{visibleTab === "experience" && (
+				{visibleTab === "all" ? (
+					<>
+						<Section title="📋 Experiencia">
 							<ExperienceList experience={experience} />
-						)}
-						{visibleTab === "education" && (
+						</Section>
+						<Section title="🎓 Educación">
 							<EducationList education={education} />
-						)}
-						{visibleTab === "it-skills" && (
+						</Section>
+						<Section title="🖥️ Competencias informáticas">
 							<div className="computer-skills">
 								<HardSkills
 									subtitle="Lenguajes de desarrollo"
@@ -78,14 +76,43 @@ export const InteractiveCV = ({ cvData }) => {
 								/>
 								<HardSkills subtitle="Tecnologías" items={technologies} />
 							</div>
-						)}
-						{visibleTab === "soft-skills" && (
+						</Section>
+						<Section title="🔧 Soft Skills">
 							<SkillList softSkills={softSkills} />
-						)}
-						{visibleTab === "languages" && (
+						</Section>
+						<Section title="💬 Idiomas">
 							<LanguageList languages={languages} />
-						)}
-					</Section>
+						</Section>
+					</>
+				) : (
+					currentTab && (
+						<Section
+							title={currentTab.label}
+							className={animating ? "scroll-collapse" : "scroll-expand"}
+						>
+							{visibleTab === "experience" && (
+								<ExperienceList experience={experience} />
+							)}
+							{visibleTab === "education" && (
+								<EducationList education={education} />
+							)}
+							{visibleTab === "it-skills" && (
+								<div className="computer-skills">
+									<HardSkills
+										subtitle="Lenguajes de desarrollo"
+										items={devLanguages}
+									/>
+									<HardSkills subtitle="Tecnologías" items={technologies} />
+								</div>
+							)}
+							{visibleTab === "soft-skills" && (
+								<SkillList softSkills={softSkills} />
+							)}
+							{visibleTab === "languages" && (
+								<LanguageList languages={languages} />
+							)}
+						</Section>
+					)
 				)}
 			</div>
 		</div>

--- a/src/components/Section/Section.css
+++ b/src/components/Section/Section.css
@@ -37,3 +37,9 @@
 		gap: 40px;
 	}
 }
+
+@media print {
+	.separator {
+		margin: 20px 0;
+	}
+}


### PR DESCRIPTION
# New Feature: Add PDF download button and "Full CV" tab to InteractiveCV

## Description

This pull request enhances the `InteractiveCV` component by adding a button that allows users to download the full CV as a PDF. Additionally, a new "Full CV" tab has been introduced, enabling users to view all sections of the CV at once within the interactive layout.

### Changes:

- Added a "Download PDF" button to the `InteractiveCV` interface
- Implemented functionality to trigger browser print-to-PDF via `window.print()`
- Introduced a new tab labeled "Full CV" that renders all CV sections in a single scrollable view
- Updated tab logic and styling to accommodate the new option
- Ensured consistent appearance across light and dark modes

These additions improve usability by allowing easy export of the CV and offering users a complete overview without needing to switch between sections.

### Screenshots
<img width="176" height="52" alt="image" src="https://github.com/user-attachments/assets/9ecbc056-2297-4a20-bf24-e4f9a978f304" />

<img width="272" height="181" alt="image" src="https://github.com/user-attachments/assets/31c5a3a3-dc8f-48d0-91b7-62108cd0f492" />
